### PR TITLE
ENT-1698 Added an additional argument for the permission_required decorator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[0.1.8] - 2019-03-22
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Adding an additional argument for the permission_required decorator
+
 [0.1.7] - 2019-03-20
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/decorators.py
+++ b/edx_rbac/decorators.py
@@ -3,6 +3,8 @@ Taken from https://github.com/escodebar/django-rest-framework-rules/blob/master/
 """
 from __future__ import absolute_import, unicode_literals
 
+from functools import wraps
+
 
 def permission_required(*permissions, **decorator_kwargs):
     """
@@ -14,6 +16,7 @@ def permission_required(*permissions, **decorator_kwargs):
     """
     def decorator(view):
         """Verify permissions decorator."""
+        @wraps(view)
         def wrapped_view(self, request, *args, **kwargs):
             """Wrap for the view function."""
             fn = decorator_kwargs.get('fn', None)
@@ -33,5 +36,7 @@ def permission_required(*permissions, **decorator_kwargs):
                 )
 
             return view(self, request, *args, **kwargs)
-        return wrapped_view
+
+        enabled = decorator_kwargs.get('enabled', False)
+        return wrapped_view if enabled else view
     return decorator


### PR DESCRIPTION
Description: This PR adds an additional argument 'enabled' for the permission_required decorator. This is needed to enable waffle flags for incremental release cycles.