### PR TITLE
handle explicit access when get_context() is None

### DIFF
--- a/edx_rbac/utils.py
+++ b/edx_rbac/utils.py
@@ -103,6 +103,8 @@ def user_has_access_via_database(user, role_name, role_assignment_class, context
     except role_assignment_class.DoesNotExist:
         return False
     if context:
+        if role_assignment.get_context() is None:
+            return True
         return role_assignment.get_context() == context
     return True
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -224,6 +224,24 @@ class TestUtilsWithDatabaseRequirements(TestCase):
             'a-test-context'
         )
 
+    def test_user_has_access_via_database_with_no_context(self):
+        """
+        Access check should return true if RoleAssignment exists for user.
+        This case handles checking if the context matches.
+        """
+        ConcreteUserRoleAssignment.objects.create(
+            user=self.user,
+            role=self.role
+        )
+
+        with patch('tests.models.ConcreteUserRoleAssignment.get_context', return_value=None) as mock_get_context:
+            assert user_has_access_via_database(
+                self.user,
+                'coupon-manager',
+                ConcreteUserRoleAssignment,
+                'a-test-context'
+            )
+
     def test_user_has_no_access_via_database_with_context(self):
         """
         Access check should return false if RoleAssignment does not exist for user.


### PR DESCRIPTION
This PR made changes to return `True` when `role_assignment.get_context() is None`.

we have added a nullable `enterprise_id` in role assignment model and `get_context()` will return `None` if `enterprise_id` is not set.

So as per my understanding we should return `True` if `role_assignment.get_context() is None`.

Currently some tests are failing in `edx-enterprise-data` because `role_assignment.get_context()` returns None for those tests.

## 

Below is the explicit context check function I have in `edx-enterprise-data`
```python
def has_correct_context_for_explicit_access(request):
    """
    Check if request has correct role assignement context.
    """
    __, __, kwargs = resolve(request.path)
    enterprise_id_in_request = kwargs.get('enterprise_id')

    try:
        role_assignment = EnterpriseDataRoleAssignment.objects.get(
            user=request.user,
            role__name=ENTERPRISE_DATA_ADMIN_ROLE
        )
    except EnterpriseDataRoleAssignment.DoesNotExist:
        return False

    # if there is no enterprise_id set than user is allowed
    if role_assignment.get_context() is None:
        return True

    return role_assignment.get_context() == enterprise_id_in_request
```