### PR TITLE
For api requests, the jwt token is not in the cookie

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[0.1.11] - 2019-04-08
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Get JWT token from request.auth if it is not set on the cookie. This supports client credentials oauth2 flow.
+
 [0.1.10] - 2019-04-01
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.10'
+__version__ = '0.1.11'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/utils.py
+++ b/edx_rbac/utils.py
@@ -52,7 +52,7 @@ def get_decoded_jwt_from_request(request):
     Returns a decoded jwt dict if it finds it.
     Returns a None if it does not.
     """
-    jwt_cookie = request.COOKIES.get(jwt_cookie_name(), None)
+    jwt_cookie = request.COOKIES.get(jwt_cookie_name(), None) or getattr(request, 'auth', None)
 
     if not jwt_cookie:
         return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,6 +64,23 @@ class TestUtils(TestCase):
         mock_decoder.assert_called_once()
 
     @patch('edx_rbac.utils.jwt_decode_handler')
+    def test_get_decoded_jwt_from_request_from_auth_attr(self, mock_decoder):
+        """
+        A dcoded jwt should be returned from the request auth if it is not set on the cookie.
+        """
+        payload = generate_unversioned_payload(self.request.user)
+        payload.update({
+            "roles": [
+                "some_new_role_name:some_context"
+            ]
+        })
+        jwt_token = generate_jwt_token(payload)
+        self.request.auth = jwt_token
+        get_decoded_jwt_from_request(self.request)
+
+        mock_decoder.assert_called_once()
+
+    @patch('edx_rbac.utils.jwt_decode_handler')
     def test_get_decoded_jwt_from_request_no_jwt_in_request(self, mock_decoder):
         """
         None should be returned if the request has no jwt


### PR DESCRIPTION
While testing https://github.com/edx/edx-enterprise/pull/444, it turns out that we can find the jwt token at `request.auth` when hitting the api directly, and not on the cookie.