### PR TITLE
This refactors role retrieval to remove the dependency on django models for assigning roles.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Chris Pappas <cpappas@edx.org>
 Muhammad Ammar <mammar@gmail.com>
+Dave St.Germain <dstgermain@edx.org>

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.11'
+__version__ = '0.2.0'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/models.py
+++ b/edx_rbac/models.py
@@ -83,6 +83,16 @@ class UserRoleAssignment(with_metaclass(UserRoleAssignmentCreator, TimeStampedMo
         """
         return None
 
+    @classmethod
+    def get_assignments(cls, user):
+        """
+        Return iterator of (rolename, context).
+        """
+        for assign in cls.objects.filter(
+            user=user
+        ).select_related('role'):
+            yield assign.role.name, assign.get_context()
+
     def __str__(self):
         """
         Return human-readable string representation.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# pylint: disable=C0111,W6005,W6100
+# pylint: disable=C0111,W6005,W6100,useless-suppression
 """
 Package metadata for edx_rbac.
 """

--- a/test_settings.py
+++ b/test_settings.py
@@ -53,7 +53,8 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
 }
 
 SYSTEM_WIDE_ROLE_CLASSES = [
-    'tests.ConcreteUserRoleAssignment'
+    'tests.ConcreteUserRoleAssignment',
+    'tests.test_assignments.get_assigments',
 ]
 
 AUTH_USER_MODEL = 'auth.User'

--- a/tests/test_assignments.py
+++ b/tests/test_assignments.py
@@ -1,0 +1,12 @@
+"""
+This is an example of a function-based role retriever.
+"""
+from __future__ import absolute_import, unicode_literals
+
+
+def get_assigments(user):
+    """
+    Return iterator of (role_name, context)
+    """
+    yield 'test-role', None
+    yield 'test-role2', str(user.id)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -322,7 +322,9 @@ class TestUtilsWithDatabaseRequirements(TestCase):
         )
 
         expected_claim = [
-            'coupon-manager:a-test-context'
+            'coupon-manager:a-test-context',
+            'test-role',
+            'test-role2:1',
         ]
         actual_claim = create_role_auth_claim_for_user(self.user)
         assert expected_claim == actual_claim


### PR DESCRIPTION
For instance, you can now create a role that looks up the user's membership in a group, or in an enrollment table, or any other criteria.


