### PR TITLE
Removed get_request_or_stub and get_decoded_jwt_from_request from utils.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
-[0.3.0] - 2019-05-20
+[1.0.0] - 2019-05-20
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Removed `get_request_or_stub` and `get_decoded_jwt_from_request` from utils.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[0.3.0] - 2019-05-20
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Removed `get_request_or_stub` and `get_decoded_jwt_from_request` from utils.py
+
 [0.2.1] - 2019-05-08
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.3.0'
+__version__ = '1.0.0'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/utils.py
+++ b/edx_rbac/utils.py
@@ -6,59 +6,10 @@ from __future__ import absolute_import, unicode_literals
 
 import importlib
 
-import crum
 from django.apps import apps
 from django.conf import settings
-from django.test.client import RequestFactory
-from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name
-from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
-from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
 
 ALL_ACCESS_CONTEXT = '*'
-
-
-# Taken from edx-platform
-def get_request_or_stub():
-    """
-    Return the current request or a stub request.
-
-    If called outside the context of a request, construct a fake
-    request that can be used to build an absolute URI.
-    This is useful in cases where we need to pass in a request object
-    but don't have an active request (for example, in tests, celery tasks, and XBlocks).
-    """
-    request = crum.get_current_request()
-
-    if request is None:
-
-        # The settings SITE_NAME may contain a port number, so we need to
-        # parse the full URL.
-        full_url = "http://{site_name}".format(site_name=settings.SITE_NAME)
-        parsed_url = urlparse(full_url)
-
-        # Construct the fake request.  This can be used to construct absolute
-        # URIs to other paths.
-        return RequestFactory(
-            SERVER_NAME=parsed_url.hostname,
-            SERVER_PORT=parsed_url.port or 80,
-        ).get("/")
-
-    else:
-        return request
-
-
-def get_decoded_jwt_from_request(request):
-    """
-    Grab jwt from request if possible.
-
-    Returns a decoded jwt dict if it finds it.
-    Returns a None if it does not.
-    """
-    jwt_cookie = request.COOKIES.get(jwt_cookie_name(), None) or getattr(request, 'auth', None)
-
-    if not jwt_cookie:
-        return None
-    return jwt_decode_handler(jwt_cookie)
 
 
 def request_user_has_implicit_access_via_jwt(decoded_jwt, role_name, context=None):


### PR DESCRIPTION
**Description:**
This PR removes the `get_request_or_stub` and `get_decoded_jwt_from_request` from utils.py since these functions are moves into the specific repositories in which they were being used.