### PR TITLE
ENT-1783: edx-drf-extensions versoin upgrade.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.0.1] - 2019-05-27
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* edx-drf-extensions version upgrade.
+
 [1.0.0] - 2019-05-20
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,13 +11,13 @@ django-model-utils==3.1.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.3  # via edx-drf-extensions, rest-condition
+djangorestframework==3.9.4  # via edx-drf-extensions, rest-condition
 edx-django-utils==1.0.3   # via edx-drf-extensions
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-opaque-keys==0.4.4    # via edx-drf-extensions
 future==0.17.1            # via pyjwkest
 idna==2.8                 # via requests
-newrelic==4.18.0.118      # via edx-django-utils
+newrelic==4.20.0.120      # via edx-django-utils
 pbr==5.2.0                # via stevedore
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 pycryptodomex==3.8.1      # via pyjwkest
@@ -26,9 +26,9 @@ pyjwt==1.7.1              # via djangorestframework-jwt
 pymongo==3.8.0            # via edx-opaque-keys
 python-dateutil==2.8.0    # via edx-drf-extensions
 pytz==2019.1              # via django
-requests==2.21.0          # via edx-drf-extensions, pyjwkest
+requests==2.22.0          # via edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.6.0   # via edx-drf-extensions
 six==1.12.0
 stevedore==1.30.1         # via edx-opaque-keys
-urllib3==1.24.3           # via requests
+urllib3==1.25.3           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,41 +19,41 @@ codecov==2.0.15
 configparser==3.7.4
 contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3
-diff-cover==2.0.0
-distlib==0.2.8
+diff-cover==2.0.1
+distlib==0.2.9.post0
 django-crum==0.7.3
 django-model-utils==3.1.2
 django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.3
+djangorestframework==3.9.4
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
+edx-lint==1.2.1
 edx-opaque-keys==0.4.4
 enum34==1.1.6
-filelock==3.0.10
+filelock==3.0.12
 funcsigs==1.0.2
 future==0.17.1
 futures==3.1.1
 idna==2.8
-importlib-metadata==0.9   # via path.py
+importlib-metadata==0.15  # via path.py
 inflect==2.1.0            # via jinja2-pluralize
-isort==4.3.18
+isort==4.3.20
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1
-lazy-object-proxy==1.4.0
+lazy-object-proxy==1.4.1
 markupsafe==1.1.1
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 packaging==19.0
 path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.3
 pbr==5.2.0
-pip-tools==3.6.1
+pip-tools==3.7.0
 pluggy==0.11.0
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
@@ -61,7 +61,7 @@ py==1.8.0
 pycodestyle==2.5.0
 pycryptodomex==3.8.1
 pydocstyle==3.0.0
-pygments==2.3.1           # via diff-cover
+pygments==2.4.1           # via diff-cover
 pyjwkest==1.3.2
 pyjwt==1.7.1
 pylint-celery==0.3
@@ -72,12 +72,12 @@ pymongo==3.8.0
 pyparsing==2.4.0
 pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1
+pytest==4.5.0
 python-dateutil==2.8.0
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 scandir==1.10.0
 semantic-version==2.6.0
@@ -88,8 +88,9 @@ stevedore==1.30.1
 text-unidecode==1.2
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.9.0
-urllib3==1.24.3
-virtualenv==16.5.0
+tox==3.12.1
+urllib3==1.25.3
+virtualenv==16.6.0
+wcwidth==0.1.7
 wrapt==1.11.1
-zipp==0.4.0               # via importlib-metadata
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -19,11 +19,11 @@ django-model-utils==3.1.2
 django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.3
+djangorestframework==3.9.4
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-opaque-keys==0.4.4
 edx-sphinx-theme==1.4.0
 funcsigs==1.0.2
@@ -34,7 +34,7 @@ jinja2==2.10.1
 markupsafe==1.1.1
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 packaging==19.0           # via sphinx
 pathlib2==2.3.3
 pbr==5.2.0
@@ -42,20 +42,20 @@ pluggy==0.11.0
 psutil==1.2.1
 py==1.8.0
 pycryptodomex==3.8.1
-pygments==2.3.1           # via readme-renderer, sphinx
+pygments==2.4.1           # via readme-renderer, sphinx
 pyjwkest==1.3.2
 pyjwt==1.7.1
 pymongo==3.8.0
 pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1
+pytest==4.5.0
 python-dateutil==2.8.0
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1
 readme-renderer==24.0
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 restructuredtext-lint==1.3.0  # via doc8
 scandir==1.10.0
@@ -63,9 +63,10 @@ semantic-version==2.6.0
 six==1.12.0
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.8.5
-sphinxcontrib-websupport==1.1.0  # via sphinx
+sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.30.1
 text-unidecode==1.2
 typing==3.6.6             # via sphinx
-urllib3==1.24.3
+urllib3==1.25.3
+wcwidth==0.1.7
 webencodings==0.5.1       # via bleach

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.6.1
+pip-tools==3.7.0
 six==1.12.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -17,30 +17,30 @@ click==7.0
 code-annotations==0.3.1
 configparser==3.7.4       # via pydocstyle, pylint
 coverage==4.5.3
-distlib==0.2.8            # via caniusepython3
+distlib==0.2.9.post0      # via caniusepython3
 django-crum==0.7.3
 django-model-utils==3.1.2
 django-waffle==0.16.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.3
+djangorestframework==3.9.4
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
-edx-lint==1.1.2
+edx-drf-extensions==2.3.0
+edx-lint==1.2.1
 edx-opaque-keys==0.4.4
 enum34==1.1.6             # via astroid
 funcsigs==1.0.2
 future==0.17.1
 futures==3.1.1
 idna==2.8
-isort==4.3.18
+isort==4.3.20
 jinja2==2.10.1
-lazy-object-proxy==1.4.0  # via astroid
+lazy-object-proxy==1.4.1  # via astroid
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 packaging==19.0           # via caniusepython3
 pathlib2==2.3.3
 pbr==5.2.0
@@ -60,12 +60,12 @@ pymongo==3.8.0
 pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1
+pytest==4.5.0
 python-dateutil==2.8.0
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 scandir==1.10.0
 semantic-version==2.6.0
@@ -74,5 +74,6 @@ six==1.12.0
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1
 text-unidecode==1.2
-urllib3==1.24.3
+urllib3==1.25.3
+wcwidth==0.1.7
 wrapt==1.11.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,9 +15,9 @@ django-crum==0.7.3
 django-model-utils==3.1.2
 django-waffle==0.16.0
 djangorestframework-jwt==1.11.0
-djangorestframework==3.9.3
+djangorestframework==3.9.4
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
+edx-drf-extensions==2.3.0
 edx-opaque-keys==0.4.4
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1
@@ -26,7 +26,7 @@ jinja2==2.10.1            # via code-annotations
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
 more-itertools==5.0.0     # via pytest
-newrelic==4.18.0.118
+newrelic==4.20.0.120
 pathlib2==2.3.3           # via pytest, pytest-django
 pbr==5.2.0
 pluggy==0.11.0            # via pytest
@@ -38,16 +38,17 @@ pyjwt==1.7.1
 pymongo==3.8.0
 pytest-cov==2.7.1
 pytest-django==3.4.8
-pytest==4.4.1             # via pytest-cov, pytest-django
+pytest==4.5.0             # via pytest-cov, pytest-django
 python-dateutil==2.8.0
 python-slugify==3.0.2     # via code-annotations
 pytz==2019.1
 pyyaml==5.1               # via code-annotations
-requests==2.21.0
+requests==2.22.0
 rest-condition==1.0.3
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0
 six==1.12.0
 stevedore==1.30.1
 text-unidecode==1.2       # via python-slugify
-urllib3==1.24.3
+urllib3==1.25.3
+wcwidth==0.1.7            # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -8,14 +8,14 @@ certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.3           # via codecov
-filelock==3.0.10          # via tox
+filelock==3.0.12          # via tox
 idna==2.8                 # via requests
 pluggy==0.11.0            # via tox
 py==1.8.0                 # via tox
-requests==2.21.0          # via codecov
+requests==2.22.0          # via codecov
 six==1.12.0               # via tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.9.0
-urllib3==1.24.3           # via requests
-virtualenv==16.5.0        # via tox
+tox==3.12.1
+urllib3==1.25.3           # via requests
+virtualenv==16.6.0        # via tox


### PR DESCRIPTION
**Description:**
This PR updates `edx-drf-extensions version`. The new version of `edx-drf-extensions` contains [these](https://github.com/edx/edx-drf-extensions/compare/2.2.2...2.3.0) updates.