### PR TITLE
store current request on thread local storage using crum

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[1.0.2] - 2019-07-12
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* store current request on thread local storage using crum.
+
 [1.0.1] - 2019-05-27
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/decorators.py
+++ b/edx_rbac/decorators.py
@@ -3,6 +3,8 @@ Taken from https://github.com/escodebar/django-rest-framework-rules/blob/master/
 """
 from __future__ import absolute_import, unicode_literals
 
+import crum
+
 
 def permission_required(*permissions, **decorator_kwargs):
     """
@@ -21,6 +23,8 @@ def permission_required(*permissions, **decorator_kwargs):
                 obj = fn(request, *args, **kwargs)
             else:
                 obj = fn
+
+            crum.set_current_request(request)
 
             missing_permissions = [perm for perm in permissions
                                    if not request.user.has_perm(perm, obj)]

--- a/edx_rbac/mixins.py
+++ b/edx_rbac/mixins.py
@@ -6,6 +6,7 @@ Keeps py2 backward compatibility and only holds on to the necessary bits of the 
 """
 from __future__ import absolute_import, unicode_literals
 
+import crum
 from django.core.exceptions import ImproperlyConfigured
 from six import string_types
 
@@ -42,6 +43,8 @@ class PermissionRequiredMixin(object):
         """
         Check through permissions required and throws a permission_denied if missing any.
         """
+        crum.set_current_request(request)
+
         user = request.user
         missing_permissions = [perm for perm in self.get_permission_required()
                                if not user.has_perm(perm)]


### PR DESCRIPTION
Store the current request on thread local storage to be later use by `rules.predicate`. This will always give us the correct type of underlaying request. 

For an understanding of why exactly we want this functionality, please see discussion happening on [ENT-2002](https://openedx.atlassian.net/browse/ENT-2002 )