### PR TITLE
Passthru permission object to has_perm in PermissionRequiredMixin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,12 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 
+[1.1.0] - 2020-02-18
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Update `PermissionRequiredMixin` to pass through an object to rule predicates, if `self.get_permision_required` exists and is callable
+
+
 [1.0.5] - 2019-12-18
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/how_to_guide.rst
+++ b/docs/how_to_guide.rst
@@ -133,7 +133,12 @@ Below is a ViewSet with mixin.
         pagination_class = DefaultPagination
         permission_required = 'can_access_enterprise'
 
-8. You are all setup and now when an endpoint gets a request, role based permissions will be checked for the requesting
+8. Implement the `self.get_permission_required` method on a viewset in order to retrieve the permissions
+object to check against. This object gets passed to the rule predicate(s). Without this method implemented,
+the object passed to the rule predicate(s) will always be `None`. Note: django-rules does not support filtering
+a queryset by a user's object-level permissions.
+
+9. You are all setup and now when an endpoint gets a request, role based permissions will be checked for the requesting
 user and either HTTP 403 or any other appropriate response will be returned. In case of HTTP 403, user have no access on
 requesting resource.
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.5'
+__version__ = '1.1.0'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/mixins.py
+++ b/edx_rbac/mixins.py
@@ -42,7 +42,7 @@ class PermissionRequiredMixin(object):
     def check_permissions(self, request):
         """
         Check through permissions required and throws a permission_denied if missing any.
-        
+
         If `get_permission_object` is implemented, it will be called and should return the object
         for which the @rules predicate checks against.
         """

--- a/edx_rbac/mixins.py
+++ b/edx_rbac/mixins.py
@@ -41,7 +41,9 @@ class PermissionRequiredMixin(object):
 
     def check_permissions(self, request):
         """
-        Check through permissions required and throws a permission_denied if missing any.
+        Check through permissions required and throws a permission_denied if missing any. If
+        `get_permission_object` is implemented, it will be called and should return the object
+        for which the @rules predicate checks against.
         """
         crum.set_current_request(request)
         user = request.user

--- a/edx_rbac/mixins.py
+++ b/edx_rbac/mixins.py
@@ -44,10 +44,15 @@ class PermissionRequiredMixin(object):
         Check through permissions required and throws a permission_denied if missing any.
         """
         crum.set_current_request(request)
-
         user = request.user
+
+        if hasattr(self, 'get_permission_object') and callable(self.get_permission_object):
+            obj = self.get_permission_object()
+        else:
+            obj = None
+
         missing_permissions = [perm for perm in self.get_permission_required()
-                               if not user.has_perm(perm)]
+                               if not user.has_perm(perm, obj)]
 
         if any(missing_permissions):
             self.permission_denied(

--- a/edx_rbac/mixins.py
+++ b/edx_rbac/mixins.py
@@ -41,8 +41,9 @@ class PermissionRequiredMixin(object):
 
     def check_permissions(self, request):
         """
-        Check through permissions required and throws a permission_denied if missing any. If
-        `get_permission_object` is implemented, it will be called and should return the object
+        Check through permissions required and throws a permission_denied if missing any.
+        
+        If `get_permission_object` is implemented, it will be called and should return the object
         for which the @rules predicate checks against.
         """
         crum.set_current_request(request)


### PR DESCRIPTION
This PR updates the `PermissionRequiredMixin` to call `self.get_pagination_object()` if that attr exists and is callable. The result is passed to `user.has_perm()`, which properly sends the object  to the rule predicates defined in the consuming app (in this case, enterprise-catalog).