### PR TITLE
ENT-2641 Fix multi-context support for implicit jwt check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 
+[1.1.1] - 2020-03-02
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Fix bug in implicit role check when the same role has multiple contexts available.
+
 [1.1.0] - 2020-02-18
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -4,6 +4,6 @@ Library to help managing role based access controls for django apps.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/edx_rbac/utils.py
+++ b/edx_rbac/utils.py
@@ -40,13 +40,16 @@ def request_user_has_implicit_access_via_jwt(decoded_jwt, role_name, context=Non
         # split should be more robust because of our cousekeys having colons
         role_in_jwt, __, context_in_jwt = role_data.partition(':')
         mapped_roles = settings.SYSTEM_TO_FEATURE_ROLE_MAPPING.get(role_in_jwt, [])
-        feature_roles.update({role: context_in_jwt for role in mapped_roles})
+        for role in mapped_roles:
+            if role not in feature_roles:
+                feature_roles[role] = []
+            feature_roles[role].append(context_in_jwt)
 
     if role_name in feature_roles:
         if not context:
             return True
         else:
-            return feature_roles[role_name] in (context, ALL_ACCESS_CONTEXT)
+            return context in feature_roles[role_name] or ALL_ACCESS_CONTEXT in feature_roles[role_name]
 
     return False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,6 +160,77 @@ class TestUtils(TestCase):
             'some_context'
         )
 
+    def test_user_with_multiple_contexts_has_access_via_jwt(self):
+        """
+        Helper function should discern what roles user has based on role data
+        in jwt, and then return true if any of those match the role we're
+        asking about. This case handles checking if each available context
+        matches when the user has access to multiple contexts.
+        """
+        toy_decoded_jwt = {
+            "roles": [
+                "coupon-manager:some_context",
+                "coupon-manager:some_other_context"
+            ]
+        }
+        assert request_user_has_implicit_access_via_jwt(
+            toy_decoded_jwt,
+            'coupon-management',
+            'some_context'
+        )
+
+        assert request_user_has_implicit_access_via_jwt(
+            toy_decoded_jwt,
+            'coupon-management',
+            'some_other_context'
+        )
+
+    def test_user_multiple_contexts_has_access_via_jwt_with_all_access_context(self):
+        """
+        Helper function should discern what roles user has based on role data
+        in jwt, and then return true if any of those match the role we're
+        asking about. This case handles checking if a context not specified
+        in the jwt matches when the user has access to multiple contexts,
+        one of which is the all access context.
+        """
+        toy_decoded_jwt = {
+            "roles": [
+                "coupon-manager:some_context",
+                "coupon-manager:*"
+            ]
+        }
+
+        assert request_user_has_implicit_access_via_jwt(
+            toy_decoded_jwt,
+            'coupon-management',
+            'some_context'
+        )
+
+        assert request_user_has_implicit_access_via_jwt(
+            toy_decoded_jwt,
+            'coupon-management',
+            'some_totally_different_context'
+        )
+
+    def test_user_with_multiple_contexts_has_no_access_via_jwt(self):
+        """
+        Helper function should discern what roles user has based on role data
+        in jwt, and then return true if any of those match the role we're
+        asking about. This case handles checking if a non-available context
+        does not match when the user has access to multiple other contexts.
+        """
+        toy_decoded_jwt = {
+            "roles": [
+                "coupon-manager:some_context",
+                "coupon-manager:some_other_context"
+            ]
+        }
+        assert not request_user_has_implicit_access_via_jwt(
+            toy_decoded_jwt,
+            'coupon-management',
+            'some_totally_different_context'
+        )
+
 
 class TestUtilsWithDatabaseRequirements(TestCase):
     """


### PR DESCRIPTION
When multiple contexts for the same role were available in the jwt, we were not properly executing the implicit permission check, causing some contexts that were present to fail incorrectly. This PR fixes this bug so that context checking in this case behaves as expected.