### PR TITLE
Remove temporary tests/__init__.py creation now that that file exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,7 @@ requirements: ## install development environment requirements
 	pip-sync requirements/dev.txt requirements/private.*
 
 test: clean ## run tests in the current virtualenv
-	touch tests/__init__.py
 	pytest
-	rm tests/__init__.py
 
 diff_cover: test ## find diff lines that need test coverage
 	diff-cover coverage.xml


### PR DESCRIPTION
Small follow-on to https://github.com/edx/edx-rbac/pull/37 -- or we could just have `make test` run `tox`, but this at least keeps `make test` from messing up the working dir.