### PR TITLE
Update PyPI token

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -25,4 +25,4 @@ jobs:
           uses: pypa/gh-action-pypi-publish@master
           with:
             user: __token__
-            password: ${{ PYPI_UPLOAD_TOKEN }}
+            password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/edx_rbac/__init__.py
+++ b/edx_rbac/__init__.py
@@ -2,6 +2,6 @@
 Library to help managing role based access controls for django apps.
 """
 
-__version__ = '1.3.3'
+__version__ = '1.3.4'
 
 default_app_config = 'edx_rbac.apps.EdxRbacConfig'  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.8'
     ],
 )


### PR DESCRIPTION
**Issue:** [BOM-2207](https://openedx.atlassian.net/browse/BOM-2207)

### Description
- Updated PyPI credentials to use `secrets.PYPI_UPLOAD_TOKEN` as password.
- Updated the Python classifiers.
-  Bumped the version to `1.4.0`.